### PR TITLE
Add Fastly result

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It is important to note that what matters most is whatever the edge is that term
 | Akamai                  | Pass &#9989;  | [Nov 26, 2018](https://www.webpagetest.org/result/181128_WJ_4f388eef1d2e03e513ff74214860d2f0/) | [Stephen Ludin](https://twitter.com/sludin)
 | Amazon CloudFront       | FAIL &#10060; | [Nov 26, 2018](https://www.webpagetest.org/result/181126_05_fafd92c1036649029f5392851e0234c2/) | [Andy Davies](https://twitter.com/AndyDavies)
 | Cloudflare              | Pass &#9989;  | [Nov 26, 2018](https://www.webpagetest.org/result/181126_G7_3abfb12925925f8debe527c779c46dfe/) | [Patrick Meenan](https://twitter.com/patmeenan)
+| Fastly                  | FAIL &#10060; | [Nov 30, 2018](https://www.webpagetest.org/result/181130_6R_ebaa7da93fb92350c1350ab7c0690d41/) | [Ryan Townsend](https://twitter.com/ryantownsend)
 | Google Firebase         | FAIL &#10060; | [Nov 28, 2018](https://www.webpagetest.org/result/181128_PA_9c3c428698111b81df1cc6eef2e0520c/) | [Patrick Meenan](https://twitter.com/patmeenan)
 | Google Storage          | FAIL &#10060; | [Nov 26, 2018](https://www.webpagetest.org/result/181126_XF_361c1789d782990b27a0141e838694bf/) | [Patrick Meenan](https://twitter.com/patmeenan)
 | Microsoft Azure         | FAIL &#10060; | [Nov 29, 2018](https://www.webpagetest.org/result/181129_31_90c38d46fe43105554bbcb05dcb25378/) | [Andy Davies](https://twitter.com/AndyDavies)


### PR DESCRIPTION
Fastly appeared to reprioritise properly for my first 3 WPT results, then the next 6 showed the same partial reprioritisation as CloudFront:

**Result 1 out of 9:**

![Result 1 of 9](https://user-images.githubusercontent.com/12299/49319471-fa19ea00-f4f4-11e8-8440-31a7e490195e.png)

**Result 5 out of 9:**

![Result 5 of 9](https://user-images.githubusercontent.com/12299/49319475-ff773480-f4f4-11e8-8374-e7b6420833f3.png)

The above waterfalls are from: https://www.webpagetest.org/result/181130_JG_e7632c7c2689c6d351673fc6feb80beb/

I re-ran and consistently got the partial reprioritisation (see https://www.webpagetest.org/result/181130_6R_ebaa7da93fb92350c1350ab7c0690d41/) – this is what I committed as the result link.